### PR TITLE
Updated bash command in README

### DIFF
--- a/Integrations/All Countermeasures Report/README.MD
+++ b/Integrations/All Countermeasures Report/README.MD
@@ -7,7 +7,7 @@ The purpose of this script is to call all countermeasures from all libraries sto
 1. Set up the virtual environment
 
 ```bash
-python3 -m menv all-CM-Report
+python3 -m venv all-CM-Report
 ```
 
 Activate the virtual environment


### PR DESCRIPTION
README.md file had an incorrect bash command 'python3 -m menv all-CM-Report'. I am proposing we change this to 'venv'. 
This appears to be a simple typo.